### PR TITLE
Support for Subject Alternative Name (SAN)

### DIFF
--- a/openssl-configurations/domain-certificate-signing-requests.conf
+++ b/openssl-configurations/domain-certificate-signing-requests.conf
@@ -13,13 +13,12 @@ distinguished_name = req_distinguished_name
 req_extensions = req_extensions
 
 [ req_distinguished_name ]
-CN = <%= domain %>
+CN = <%= commonName %>
 
 [ req_extensions ]
 basicConstraints = CA:FALSE
 subjectAltName = @subject_alt_names
 subjectKeyIdentifier = hash
 
-[ subject_alt_names ]
-DNS.1 = <%= domain %>
-DNS.2 = *.<%= domain %>
+[ subject_alt_names ] <% altNames.forEach(function(name, idx) { %>
+DNS.<%= idx %> = <%= name %><% }) %>

--- a/openssl-configurations/domain-certificates.conf
+++ b/openssl-configurations/domain-certificates.conf
@@ -34,6 +34,5 @@ keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 subjectAltName = @subject_alt_names
 
-[ subject_alt_names ]
-DNS.1 = <%= domain %>
-DNS.2 = *.<%= domain %>
+[ subject_alt_names ] <% altNames.forEach(function(altName, idx) { %>
+DNS.<%= idx %> = <%= altName %><% }) %>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "devcert",
+  "name": "@mnorth/devcert",
   "version": "1.1.0",
   "description": "Generate trusted local SSL/TLS certificates for local SSL development",
   "main": "dist/index.js",

--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -4,7 +4,7 @@ import createDebug from 'debug';
 import { sync as commandExists } from 'command-exists';
 import { run } from '../utils';
 import { Options } from '../index';
-import { addCertificateToNSSCertDB, assertNotTouchingFiles, openCertificateInFirefox, closeFirefox, removeCertificateFromNSSCertDB } from './shared';
+import { addCertificateToNSSCertDB, assertNotTouchingFiles, openCertificateInFirefox, closeFirefox, removeCertificateFromNSSCertDB, HOME } from './shared';
 import { Platform } from '.';
 
 const debug = createDebug('devcert:platforms:macos');
@@ -12,10 +12,9 @@ const debug = createDebug('devcert:platforms:macos');
 const getCertUtilPath = () => path.join(run('brew --prefix nss').toString().trim(), 'bin', 'certutil');
 
 export default class MacOSPlatform implements Platform {
-
   private FIREFOX_BUNDLE_PATH = '/Applications/Firefox.app';
   private FIREFOX_BIN_PATH = path.join(this.FIREFOX_BUNDLE_PATH, 'Contents/MacOS/firefox');
-  private FIREFOX_NSS_DIR = path.join(process.env.HOME, 'Library/Application Support/Firefox/Profiles/*');
+  private FIREFOX_NSS_DIR = path.join(HOME, 'Library/Application Support/Firefox/Profiles/*');
 
   private HOST_FILE_PATH = '/etc/hosts';
 

--- a/src/platforms/linux.ts
+++ b/src/platforms/linux.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { existsSync as exists, readFileSync as read, writeFileSync as writeFile } from 'fs';
 import createDebug from 'debug';
 import { sync as commandExists } from 'command-exists';
-import { addCertificateToNSSCertDB, assertNotTouchingFiles, openCertificateInFirefox, closeFirefox, removeCertificateFromNSSCertDB } from './shared';
+import { addCertificateToNSSCertDB, assertNotTouchingFiles, openCertificateInFirefox, closeFirefox, removeCertificateFromNSSCertDB, HOME } from './shared';
 import { run } from '../utils';
 import { Options } from '../index';
 import UI from '../user-interface';
@@ -12,8 +12,8 @@ const debug = createDebug('devcert:platforms:linux');
 
 export default class LinuxPlatform implements Platform {
 
-  private FIREFOX_NSS_DIR = path.join(process.env.HOME, '.mozilla/firefox/*');
-  private CHROME_NSS_DIR = path.join(process.env.HOME, '.pki/nssdb');
+  private FIREFOX_NSS_DIR = path.join(HOME, '.mozilla/firefox/*');
+  private CHROME_NSS_DIR = path.join(HOME, '.pki/nssdb');
   private FIREFOX_BIN_PATH = '/usr/bin/firefox';
   private CHROME_BIN_PATH = '/usr/bin/google-chrome';
 

--- a/src/platforms/shared.ts
+++ b/src/platforms/shared.ts
@@ -13,6 +13,10 @@ import { execSync as exec } from 'child_process';
 
 const debug = createDebug('devcert:platforms:shared');
 
+
+export const HOME = process.env.HOME!;
+if (typeof HOME === 'undefined') throw new Error('HOME environment variable was not set. It should be something like "/Users/exampleName"');
+
 /**
  *  Given a directory or glob pattern of directories, run a callback for each db
  *  directory, with a version argument.
@@ -111,7 +115,9 @@ export async function openCertificateInFirefox(firefoxPath: string, certPath: st
   debug('Adding devert to Firefox trust stores manually. Launching a webserver to host our certificate temporarily ...');
   let port = await getPort();
   let server = http.createServer(async (req, res) => {
-    let { pathname } = url.parse(req.url);
+    const { url: reqUrl } = req;
+    if (!reqUrl) throw new Error(`Request url was found to be empty: "${JSON.stringify(reqUrl)}"`)
+    let { pathname } = url.parse(reqUrl);
     if (pathname === '/certificate') {
       res.writeHead(200, { 'Content-type': 'application/x-x509-ca-cert' });
       res.write(readFile(certPath));

--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -10,7 +10,7 @@ import UI from '../user-interface';
 
 const debug = createDebug('devcert:platforms:windows');
 
-let encryptionKey: string;
+let encryptionKey: string | null;
 
 export default class WindowsPlatform implements Platform {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
       "baseUrl": ".",
       "skipLibCheck": true,
       "sourceRoot": ".",
+      "strictNullChecks": true,
       "noUnusedLocals": true,
       "esModuleInterop": true
   }


### PR DESCRIPTION
This should allow us to use SANs to create certificates that are valid for more than one domain

```js
const {key, cert} = await devcert.certificateFor('example-eu.com', ['example-us.com']);

```