### PR TITLE
Check for existence of certs before attempting to delete them

### DIFF
--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { writeFileSync as writeFile, existsSync as exists, readFileSync as read } from 'fs';
+import { writeFileSync as writeFile, existsSync as exists, readFileSync as read, existsSync } from 'fs';
 import createDebug from 'debug';
 import { sync as commandExists } from 'command-exists';
 import { run } from '../utils';
@@ -59,7 +59,9 @@ export default class MacOSPlatform implements Platform {
   removeFromTrustStores(certificatePath: string) {
     debug('Removing devcert root CA from macOS system keychain');
     try {
-      run(`sudo security remove-trusted-cert -d "${ certificatePath }"`);
+      if (existsSync(certificatePath)) {
+        run(`sudo security remove-trusted-cert -d "${ certificatePath }"`);
+      }
     } catch(e) {
       debug(`failed to remove ${ certificatePath } from macOS cert store, continuing. ${ e.toString() }`);
     }

--- a/src/platforms/shared.ts
+++ b/src/platforms/shared.ts
@@ -4,6 +4,7 @@ import createDebug from 'debug';
 import assert from 'assert';
 import getPort from 'get-port';
 import http from 'http';
+import { existsSync } from 'fs';
 import { sync as glob } from 'glob';
 import { readFileSync as readFile, existsSync as exists } from 'fs';
 import { run } from '../utils';
@@ -49,7 +50,9 @@ export function removeCertificateFromNSSCertDB(nssDirGlob: string, certPath: str
   doForNSSCertDB(nssDirGlob, (dir, version) => {
     const dirArg = version === 'modern' ? `sql:${ dir }` : dir;
     try {
-      run(`${ certutilPath } -A -d "${ dirArg }" -t 'C,,' -i "${ certPath }" -n devcert`)
+      if (existsSync(certPath)) {
+        run(`${ certutilPath } -A -d "${ dirArg }" -t 'C,,' -i "${ certPath }" -n devcert`)
+      }
     } catch (e) {
       debug(`failed to remove ${ certPath } from ${ dir }, continuing. ${ e.toString() }`)
     }


### PR DESCRIPTION
This fix resolves an issue where we were seeing
```
certutil:  unable to open "/Users/mnorth/Library/Application Support/devcert/certificate-authority/certificate.cert" for reading (-5950, 2).
```
in stderr during successful operation. I'd rather avoid the hard fail (and contamination of terminal output) and check first before deleting