### PR TITLE
Allow specification of cert duration

### DIFF
--- a/openssl-configurations/certificate-authority-self-signing.conf
+++ b/openssl-configurations/certificate-authority-self-signing.conf
@@ -12,7 +12,7 @@ distinguished_name = req_distinguished_name
 # to add to the certificate request.
 x509_extensions = v3_ca
 # How long is the CA valid for
-default_days = 7000
+default_days = 90
 
 [ req_distinguished_name ]
 CN = devcert

--- a/openssl-configurations/domain-certificates.conf
+++ b/openssl-configurations/domain-certificates.conf
@@ -19,7 +19,7 @@ utf8 = yes
 req_extensions = req_extensions
 x509_extensions = domain_certificate_extensions
 # How long is the domain cert good for
-default_days = 7000
+default_days = 14
 # What do CSRs need to supply?
 policy = loose_policy
 

--- a/src/certificate-authority.ts
+++ b/src/certificate-authority.ts
@@ -20,7 +20,7 @@ import {
 import currentPlatform from './platforms';
 import { openssl, mktmp } from './utils';
 import { generateKey } from './certificates';
-import { Options } from './index';
+import { Options, CertOptions } from './index';
 
 const debug = createDebug('devcert:certificate-authority');
 
@@ -28,7 +28,7 @@ const debug = createDebug('devcert:certificate-authority');
  * Install the once-per-machine trusted root CA. We'll use this CA to sign
  * per-app certs.
  */
-export default async function installCertificateAuthority(options: Options = {}): Promise<void> {
+export default async function installCertificateAuthority(options: Options = {}, certOptions: CertOptions): Promise<void> {
   debug(`Uninstalling existing certificates, which will be void once any existing CA is gone`);
   uninstall();
   ensureConfigDirs();
@@ -43,7 +43,7 @@ export default async function installCertificateAuthority(options: Options = {})
   generateKey(rootKeyPath);
 
   debug(`Generating a CA certificate`);
-  openssl(`req -new -x509 -config "${ caSelfSignConfig }" -key "${ rootKeyPath }" -out "${ rootCACertPath }" -days 825`);
+  openssl(`req -new -x509 -config "${ caSelfSignConfig }" -key "${ rootKeyPath }" -out "${ rootCACertPath }" -days ${certOptions.caCertExpiry}`);
 
   debug('Saving certificate authority credentials');
   await saveCertificateAuthorityCredentials(rootKeyPath);

--- a/src/certificates.ts
+++ b/src/certificates.ts
@@ -5,6 +5,7 @@ import { chmodSync as chmod } from 'fs';
 import { pathForDomain, withDomainSigningRequestConfig, withDomainCertificateConfig } from './constants';
 import { openssl } from './utils';
 import { withCertificateAuthorityCredentials } from './certificate-authority';
+import { CertOptions } from 'src';
 
 const debug = createDebug('devcert:certificates');
 
@@ -15,7 +16,7 @@ const debug = createDebug('devcert:certificates');
  * individual domain certificates are signed by the devcert root CA (which was
  * added to the OS/browser trust stores), they are trusted.
  */
-export default async function generateDomainCertificate(commonName: string, alternativeNames: string[]): Promise<void> {
+export default async function generateDomainCertificate(commonName: string, alternativeNames: string[], certOptions: CertOptions): Promise<void> {
   mkdirp(pathForDomain(commonName));
 
   debug(`Generating private key for ${ commonName }`);
@@ -25,7 +26,7 @@ export default async function generateDomainCertificate(commonName: string, alte
   debug(`Generating certificate signing request for ${ commonName }`);
   let csrFile = pathForDomain(commonName, `certificate-signing-request.csr`);
   withDomainSigningRequestConfig(commonName, alternativeNames, (configpath) => {
-    openssl(`req -new -config "${ configpath }" -key "${ domainKeyPath }" -out "${ csrFile }"`);
+    openssl(`req -new -config "${ configpath }" -key "${ domainKeyPath }" -out "${ csrFile }" -days ${certOptions.domainCertExpiry}`);
   });
 
   debug(`Generating certificate for ${ commonName } from signing request and signing with root CA`);


### PR DESCRIPTION
This PR allows specification of a duration for the CA cert (6 months) and the domain cert (1 month) via options passed to `certificateFor`, and dramatically reduces the default duration for each by 90%. This reduces the window of exposure for a leaked cert proportionally.