### PR TITLE
Add CI pipeline via GH actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,142 @@
+name: Node.js CI
+
+on: [push, pull_request]
+
+env:
+  CI: true
+
+jobs:
+  build_12:
+    name: build
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: |
+          yarn 
+          yarn build
+          mkdir ../sync
+          tar -cf ../sync/build.tar .
+      - name: Upload build
+        uses: actions/upload-artifact@v1
+        with:
+          name: build_${{ matrix.node-version }}
+          path: ../sync
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs: [build_12, lint]
+
+    strategy:
+      matrix:
+        node-version: [8.11.3, 8.x, 10.x, 13.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn --ignore-optional
+      - run: yarn build
+      - run: |
+          mkdir ../sync
+          tar -cf ../sync/build.tar .
+      - name: Upload build
+        uses: actions/upload-artifact@v1
+        with:
+          name: build_${{ matrix.node-version }}
+          path: ../sync
+  commit_lint:
+    name: CommitLint
+    needs: build_12
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Commit Linter
+        uses: wagoid/commitlint-github-action@v1.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  lint:
+    name: ESLint
+    needs: build_12
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build
+        uses: actions/download-artifact@v1
+        with:
+          name: build_12.x
+          path: ../sync
+      - run: tar -xf ../sync/build.tar .
+      - run: yarn lint
+  updated_api_report:
+    name: API Report up-to-date
+    needs: build_12
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download build
+        uses: actions/download-artifact@v1
+        with:
+          name: build_12.x
+          path: ../sync
+      - run: tar -xf ../sync/build.tar .
+      - run: |
+          echo "API reports that are out of date: " && git diff --exit-code --name-only HEAD 'etc/*.md' && echo "NONE: this PR is ready for review\!"
+      - run: git diff -s --exit-code HEAD -- 'etc/*.md'
+  updated_docs:
+    name: Docs up-to-date
+    needs: build_12
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download build
+        uses: actions/download-artifact@v1
+        with:
+          name: build_12.x
+          path: ../sync
+      - run: tar -xf ../sync/build.tar .
+      - run: |
+          echo "Documentation files that are out of date: " && git diff --exit-code --name-only HEAD 'docs/**/*.md' && echo "NONE: this PR is ready for review\!"
+      - run: git diff -s --exit-code HEAD -- 'docs/**/*.md'
+  basic_test:
+    strategy:
+      matrix:
+        node-version: [12.x]
+    name: node LTS tests
+    needs: [build_12]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build
+        uses: actions/download-artifact@v1
+        with:
+          name: build_${{ matrix.node-version }}
+          path: ../sync
+      - run: tar -xf ../sync/build.tar .
+      - run: yarn test
+  compat_test:
+    strategy:
+      matrix:
+        node-version: [8.11.3, 8.x, 10.x, 13.x]
+    name: node tests
+    needs:
+      [build, commit_lint, lint, basic_test, updated_docs, updated_api_report]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build
+        uses: actions/download-artifact@v1
+        with:
+          name: build_${{ matrix.node-version }}
+          path: ../sync
+      - run: tar -xf ../sync/build.tar .
+      - run: yarn test

--- a/package.json
+++ b/package.json
@@ -5,14 +5,16 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "clean": "rimraf dist",
+    "build": "yarn clean && yarn build:ts",
+    "build:ts": "tsc",
     "lint": "eslint src --ext ts",
     "prepublishOnly": "yarn build",
     "test": "yarn lint"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/davewasmer/devcert.git"
+    "url": "git+https://github.com/mike-north/devcert.git"
   },
   "keywords": [
     "ssl",
@@ -20,12 +22,21 @@
     "openssl",
     "trust"
   ],
-  "author": "Dave Wasmer",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/davewasmer/devcert/issues"
+  "author": {
+    "name": "Mike North",
+    "email": "michael.l.north@gmail.com",
+    "url": "https://mike.works"
   },
-  "homepage": "https://github.com/davewasmer/devcert#readme",
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "Dave Wasmer"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/mike-north/devcert/issues"
+  },
+  "homepage": "https://github.com/mike-north/devcert#readme",
   "devDependencies": {
     "@types/command-exists": "^1.2.0",
     "@types/configstore": "^2.1.1",


### PR DESCRIPTION
Add a CI pipeline via GitHub actions. For now this just ensures that we maintain support for the required Node.js versions, and have no build/lint errors. More tests to come soon

cc: @aghassemi