### PR TITLE
Consume password-prompt as a CJS module (not ES6)

### DIFF
--- a/src/user-interface.ts
+++ b/src/user-interface.ts
@@ -1,4 +1,4 @@
-import passwordPrompt from 'password-prompt';
+import passwordPrompt = require('password-prompt');
 import { waitForUser } from './utils';
 
 /**

--- a/types/password-prompt.d.ts
+++ b/types/password-prompt.d.ts
@@ -1,1 +1,9 @@
-export default function(prompt: string): Promise<string>;
+export = prompt;
+declare function prompt(
+  ask: string,
+  options?: {
+    method: 'hide' | 'mask';
+    required: boolean;
+    default?: string;
+  }
+): Promise<string>;


### PR DESCRIPTION
Apparently `password-prompt` only has a CJS (`module.exports = class {}`) export﻿, which means we have been consumning
it incorrectly. Import is now updated, and type declarations changed to match proper use

Thanks @Ztarbox for including this in #10 originally. 
