### PR TITLE
[bug] consumers have husky hooks run

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,12 @@
   },
   "homepage": "https://github.com/mike-north/devcert#readme",
   "devDependencies": {
+    "@mike-north/types": "^1.3.2",
     "@microsoft/api-documenter": "^7.7.12",
     "@microsoft/api-extractor": "^7.7.8",
     "@types/command-exists": "^1.2.0",
     "@types/configstore": "^4.0.0",
+    "@types/date-fns": "^2.6.0",
     "@types/debug": "^4.1.5",
     "@types/dotenv": "^8.2.0",
     "@types/execa": "^0.9.0",
@@ -83,8 +85,6 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@mike-north/types": "^1.3.2",
-    "@types/date-fns": "^2.6.0",
     "application-config-path": "^0.1.0",
     "chalk": "^3.0.0",
     "command-exists": "^1.2.4",


### PR DESCRIPTION
# Summary

This is a result of husky being an optional dependency as defined here https://github.com/mike-north/types/blob/master/package.json#L44.

These optional dependencies should be a devDependency I think.

```
#!/bin/sh
# husky

# Hook created by Husky
#   Version: 3.1.0
#   At: 8/30/2021, 3:40:24 PM
#   See: https://github.com/typicode/husky#readme

# From
#   Directory: /Users/nfurniss/code/test/voyager-web/node_modules/@mike-north/types/node_modules/husky
#   Homepage: https://github.com/typicode/husky#readme

scriptPath="node_modules/@mike-north/types/node_modules/husky/run.js"
hookName=`basename "$0"`
gitParams="$*"

debug() {
  if [ "${HUSKY_DEBUG}" = "true" ] || [ "${HUSKY_DEBUG}" = "1" ]; then
    echo "husky:debug $1"
  fi
}

debug "husky v3.1.0 (created at 8/30/2021, 3:40:24 PM)"
debug "$hookName hook started"
debug "Current working directory is '`pwd`'"
```