### PR TITLE
feat: :sparkles: support CBL-Mariner

### DIFF
--- a/src/platforms/linux.ts
+++ b/src/platforms/linux.ts
@@ -36,7 +36,8 @@ export enum LinuxFlavor {
   Unknown = 0,
   Ubuntu,
   Rhel7,
-  Fedora
+  Fedora,
+  Mariner
 }
 
 async function determineLinuxFlavor(
@@ -51,6 +52,8 @@ async function determineLinuxFlavor(
       return { flav: LinuxFlavor.Ubuntu };
     case 'Fedora':
       return { flav: LinuxFlavor.Fedora };
+    case 'Mariner':
+      return { flav: LinuxFlavor.Mariner };
     default:
       return {
         flav: LinuxFlavor.Unknown,
@@ -98,6 +101,7 @@ export function linuxFlavorDetails(
   switch (flavor) {
     case LinuxFlavor.Rhel7:
     case LinuxFlavor.Fedora:
+    case LinuxFlavor.Mariner:
       return {
         caFolders: customCaRoots || [
           '/etc/pki/ca-trust/source/anchors',

--- a/test/linux-platform.test.ts
+++ b/test/linux-platform.test.ts
@@ -55,6 +55,27 @@ QUnit.module('linux platform tests', hooks => {
       ]
     });
   });
+  QUnit.test('linuxFlavorDetails - Mariner', assert => {
+    const details = linuxFlavorDetails(LinuxFlavor.Mariner);
+    assert.deepEqual(details, {
+      caFolders: [
+        '/etc/pki/ca-trust/source/anchors',
+        '/usr/share/pki/ca-trust-source'
+      ],
+      postCaPlacementCommands: [
+        {
+          command: 'sudo',
+          args: ['update-ca-trust']
+        }
+      ],
+      postCaRemovalCommands: [
+        {
+          command: 'sudo',
+          args: ['update-ca-trust']
+        }
+      ]
+    });
+  });
   QUnit.test('linuxFlavorDetails - Ubuntu', assert => {
     const details = linuxFlavorDetails(LinuxFlavor.Ubuntu);
     assert.deepEqual(details, {


### PR DESCRIPTION
Mariner works similar to RHEL7.

Added tests for the CBL-Mariner case.